### PR TITLE
Update Read the Docs configuration (automatic)

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,14 +1,10 @@
 version: 2
-
+build:
+  os: ubuntu-20.04
+  tools:
+    python: mambaforge-4.10
 sphinx:
   builder: html
   configuration: docs/source/conf.py
-
-python:
-  version: 3.7
-
 conda:
   environment: conda/environment.yml
-
-build:
-  image: latest


### PR DESCRIPTION
Howdy! :wave:

I am @readthedocs-assistant and I am sending you this pull request to upgrade the configuration of your Read the Docs project. Your project will continue working whether or not you merge it, but I recommended you take it into consideration.

_*Note*: This tool is in beta phase. Don't hesitate to ping @astrojuanlu and/or @humitos if you spot any problems._

The following migrators were applied:

- Convert the Python version to a string.

This makes the configuration valid according to the schema
and protects you from
["the Python 3.1 problem"](https://dev.to/hugovk/the-python-3-1-problem-85g).

- Migrate to `build.tools` configuration.

This uses the new base Docker image based on Ubuntu 20.04 introduced in October 2021
and picks an appropriate Python version for your project
(read [our blog post](https://blog.readthedocs.com/new-build-specification/)
for details).
Notice that now you can specify the Node.js, Rust, and Go versions as well.

*Note:* Some system dependencies are not preinstalled anymore,
so this might require manually adding them to `build.apt_packages`
(see [our
documentation](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-apt-packages>)).

- Migrate to Mamba as a drop-in replacement for Conda.

Your project requested using Mamba instead of Conda for performance reasons.
Now this is included in your configuration
and you can change it without our intervention.