### PR TITLE
Enable Grid2D/3D/4D serialization/deserialization

### DIFF
--- a/pyinterp/backends/xarray.py
+++ b/pyinterp/backends/xarray.py
@@ -320,6 +320,17 @@ class _GridHolder:
     def __repr__(self) -> str:
         return repr(self._instance)
 
+    def __reduce__(self) -> tuple:
+        """Support pickle serialization (e.g. for Dask scatter/multiprocessing).
+
+        Returns:
+            Tuple of (callable, args) allowing reconstruction of this instance.
+
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement __reduce__"
+        )
+
 
 class Grid2D(_GridHolder):
     """Build a Grid2D from Xarray data.
@@ -346,6 +357,19 @@ class Grid2D(_GridHolder):
             canonical_dimensions.data_array.values,
         )
         super().__init__(grid, canonical_dimensions.dims)
+        self._data_array = data_array
+
+    def __reduce__(self) -> tuple:
+        """Support pickle serialization (e.g. for Dask scatter/multiprocessing).
+
+        Returns:
+            Tuple of (callable, args) allowing reconstruction of this instance.
+
+        """
+        return (
+            self.__class__,
+            (self._data_array,),
+        )
 
     def bivariate(
         self,

--- a/pyinterp/backends/xarray.py
+++ b/pyinterp/backends/xarray.py
@@ -348,6 +348,7 @@ class Grid2D(_GridHolder):
 
     def __init__(self, data_array: xr.DataArray) -> None:
         """Initialize the 2D grid from an Xarray data array."""
+        object.__setattr__(self, "_data_array", data_array)
         canonical_dimensions = _get_canonical_dimensions(
             data_array, ndims=TWO_DIMENSIONS
         )
@@ -357,7 +358,6 @@ class Grid2D(_GridHolder):
             canonical_dimensions.data_array.values,
         )
         super().__init__(grid, canonical_dimensions.dims)
-        self._data_array = data_array
 
     def __reduce__(self) -> tuple:
         """Support pickle serialization (e.g. for Dask scatter/multiprocessing).
@@ -420,6 +420,7 @@ class Grid3D(_GridHolder):
 
     def __init__(self, data_array: xr.DataArray) -> None:
         """Initialize the 3D grid from an Xarray data array."""
+        object.__setattr__(self, "_data_array", data_array)
         canonical_dimensions = _get_canonical_dimensions(
             data_array, ndims=THREE_DIMENSIONS
         )
@@ -440,6 +441,18 @@ class Grid3D(_GridHolder):
             canonical_dimensions.data_array.values,
         )
         super().__init__(grid, canonical_dimensions.dims)
+
+    def __reduce__(self) -> tuple:
+        """Support pickle serialization (e.g. for Dask scatter/multiprocessing).
+
+        Returns:
+            Tuple of (callable, args) allowing reconstruction of this instance.
+
+        """
+        return (
+            self.__class__,
+            (object.__getattribute__(self, "_data_array"),),
+        )
 
     def trivariate(
         self,
@@ -492,6 +505,7 @@ class Grid4D(_GridHolder):
 
     def __init__(self, data_array: xr.DataArray) -> None:
         """Initialize the 4D grid from an Xarray data array."""
+        object.__setattr__(self, "_data_array", data_array)
         canonical_dimensions = _get_canonical_dimensions(
             data_array, ndims=FOUR_DIMENSIONS
         )
@@ -516,6 +530,18 @@ class Grid4D(_GridHolder):
             canonical_dimensions.data_array.values,
         )
         super().__init__(grid, canonical_dimensions.dims)
+
+    def __reduce__(self) -> tuple:
+        """Support pickle serialization (e.g. for Dask scatter/multiprocessing).
+
+        Returns:
+            Tuple of (callable, args) allowing reconstruction of this instance.
+
+        """
+        return (
+            self.__class__,
+            (object.__getattribute__(self, "_data_array"),),
+        )
 
     def quadrivariate(
         self,

--- a/pyinterp/tests/backends/test_xarray.py
+++ b/pyinterp/tests/backends/test_xarray.py
@@ -288,6 +288,23 @@ class TestGrid2D:
         assert np.array_equal(grid_restored.y, grid.y)
         assert np.array_equal(grid_restored.array, grid.array)
 
+    def test_pickle_serialization_cartesian(
+        self, cartesian_2d_data: xr.DataArray
+    ) -> None:
+        """Test pickle serialization/deserialization.
+
+        Uses Cartesian data.
+        """
+        grid = Grid2D(cartesian_2d_data)
+
+        blob = pickle.dumps(grid)
+        grid_restored = pickle.loads(blob)
+
+        assert grid_restored.ndim == 2
+        assert np.array_equal(grid_restored.x, grid.x)
+        assert np.array_equal(grid_restored.y, grid.y)
+        assert np.array_equal(grid_restored.array, grid.array)
+
 
 class TestGrid3D:
     """Test Grid3D class."""
@@ -325,6 +342,35 @@ class TestGrid3D:
         result = grid.trivariate(coords, method="bilinear")
         assert result.shape == (1,)
 
+    def test_pickle_serialization(
+        self, geodetic_3d_data: xr.DataArray
+    ) -> None:
+        """Test pickle serialization/deserialization."""
+        grid = Grid3D(geodetic_3d_data)
+
+        blob = pickle.dumps(grid)
+        grid_restored = pickle.loads(blob)
+
+        assert grid_restored.ndim == 3
+        assert np.array_equal(grid_restored.x, grid.x)
+        assert np.array_equal(grid_restored.y, grid.y)
+        assert np.array_equal(grid_restored.array, grid.array)
+
+    def test_pickle_serialization_temporal(
+        self, geodetic_3d_temporal_data: xr.DataArray
+    ) -> None:
+        """Test pickle serialization/deserialization with temporal axis."""
+        grid = Grid3D(geodetic_3d_temporal_data)
+
+        blob = pickle.dumps(grid)
+        grid_restored = pickle.loads(blob)
+
+        assert grid_restored.ndim == 3
+        assert grid_restored._datetime64 is not None
+        assert np.array_equal(grid_restored.x, grid.x)
+        assert np.array_equal(grid_restored.y, grid.y)
+        assert np.array_equal(grid_restored.array, grid.array)
+
 
 class TestGrid4D:
     """Test Grid4D class."""
@@ -340,6 +386,20 @@ class TestGrid4D:
         """Test Grid4D initialization fails with 2D data."""
         with pytest.raises(ValueError, match="number of dimensions"):
             Grid4D(geodetic_2d_data)
+
+    def test_pickle_serialization(
+        self, geodetic_4d_data: xr.DataArray
+    ) -> None:
+        """Test pickle serialization/deserialization."""
+        grid = Grid4D(geodetic_4d_data)
+
+        blob = pickle.dumps(grid)
+        grid_restored = pickle.loads(blob)
+
+        assert grid_restored.ndim == 4
+        assert np.array_equal(grid_restored.x, grid.x)
+        assert np.array_equal(grid_restored.y, grid.y)
+        assert np.array_equal(grid_restored.array, grid.array)
 
 
 class TestRegularGridInterpolator:

--- a/pyinterp/tests/backends/test_xarray.py
+++ b/pyinterp/tests/backends/test_xarray.py
@@ -4,6 +4,7 @@
 # BSD-style license that can be found in the LICENSE file.
 """Tests for the xarray backend module."""
 
+import pickle
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -272,6 +273,20 @@ class TestGrid2D:
         }
         result = grid.bivariate(coords, method="bilinear")
         assert result.shape == (1,)
+
+    def test_pickle_serialization(
+        self, geodetic_2d_data: xr.DataArray
+    ) -> None:
+        """Test Grid2D pickle serialization/deserialization."""
+        grid = Grid2D(geodetic_2d_data)
+
+        blob = pickle.dumps(grid)
+        grid_restored = pickle.loads(blob)
+
+        assert grid_restored.ndim == 2
+        assert np.array_equal(grid_restored.x, grid.x)
+        assert np.array_equal(grid_restored.y, grid.y)
+        assert np.array_equal(grid_restored.array, grid.array)
 
 
 class TestGrid3D:


### PR DESCRIPTION
This PR implements the __reduce__ method to enable pickle serialization/deserialization of Grid2D/3D/4D objects.

Here is an example of code that was not working before :

```
import numpy as np
import xarray as xr
from pyinterp.backends.xarray import Grid2D

lon = np.arange(-180.0, 180.0, 1.0)
lat = np.arange(-90.0, 90.0, 1.0)
data = np.random.rand(len(lon), len(lat)).astype(np.float64)

data_array = xr.DataArray(
    data,
    dims=["longitude", "latitude"],
    coords={
        "longitude": lon,
        "latitude": lat,
    },
)

grid = Grid2D(data_array)

import pickle
# Sérialisation
blob = pickle.dumps(grid)

# Désérialisation
grid2 = pickle.loads(blob)
print(grid2)
```